### PR TITLE
patch if the "capacity" file not exists

### DIFF
--- a/tp-battery-icon.py
+++ b/tp-battery-icon.py
@@ -221,7 +221,10 @@ class ControlACPI():
         return state.rstrip()
 
     def get_percentage(self):
-        percent = self.read_sysfs("capacity")
+        try:
+            percent = self.read_sysfs("capacity")
+        except Exception:
+            percent = int(self.read_sysfs("energy_full")) / int(self.read_sysfs("energy_now")) * 100.0
         return int(percent)
 
     def get_time_running(self):


### PR DESCRIPTION
getPercentage tries to read the capacity file, but fails if capacity not exists in the current layout.

I on Xubuntu 12.10 don't have such a layout, therefore my improvement suggestion:
Changed it to energy_full / energy_now if an error occurs during reading "capacity".
