### PR TITLE
Fixes errors on recent kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# tp-battery-icon
+With thanks to https://github.com/phragment/tp-battery-icon.
+
+This repo contains fixes allowing it to work on more recent hardware, currently running on my T480s. 
+
+Use at your own risk, I garuantee nothing.


### PR DESCRIPTION
This fixes the functionality of the icon on kernels from 3.10 through latest, also sanitizes some outputs from the messaging. 

This commit makes this functional on my 5.5.5 kernel running on a T480s and should bring a new lease of life to the script.